### PR TITLE
Add support for preexisting commit template (3)

### DIFF
--- a/git/integration.go
+++ b/git/integration.go
@@ -49,7 +49,7 @@ func SetCommitTemplate(path string) (err error) {
 // UnsetCommitTemplate removes local Git commit template configuration.
 func UnsetCommitTemplate() (err error) {
 	cmd := exec.Command("git", "config", "--unset", "commit.template")
-	err = cmd.Run()
+	_ = cmd.Run()
 	return
 }
 

--- a/pair.go
+++ b/pair.go
@@ -15,6 +15,7 @@ const version = "1.0.0-alpha" // adheres to semantic versioning
 // Stop removes the co-author declaration from the commit template, if any.
 func Stop(out, errors io.Writer) error {
 	commitTemplatePath, _, err := git.GetCommitTemplatePath()
+	ensureExists(commitTemplatePath)
 	if err != nil {
 		switch err.(type) {
 		case *git.NoCommitTemplateConfigurationError:


### PR DESCRIPTION
This PR is a follow up on #3 

It comes out automated testing on the `pair` package would be welcome.