### PR TITLE
Add support for preexisting commit template (4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
   language: go
   go:
-    - "1.10"
+    - "1.12"
   install: "make install-for-testing"
   script: "make test"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,18 +35,20 @@ func main() {
 		os.Exit(fail(os.Stderr, err, 0))
 	}
 
+	git := pair.GetGitConnector()
+
 	switch os.Args[1] {
 	case "--version":
 		_ = pair.Version(os.Stdout, os.Stderr)
 		os.Exit(0)
 	case "with":
-		err = pair.With(os.Stdout, os.Stderr, os.Args[2])
+		err = pair.With(git, os.Stdout, os.Stderr, os.Args[2])
 		if err != nil {
 			os.Exit(fail(os.Stderr, err, 20))
 		}
 		os.Exit(0)
 	case "stop":
-		err = pair.Stop(os.Stdout, os.Stderr)
+		err = pair.Stop(git, os.Stdout, os.Stderr)
 		if err != nil {
 			os.Exit(fail(os.Stderr, err, 21))
 		}

--- a/git/connector.go
+++ b/git/connector.go
@@ -1,0 +1,8 @@
+package git
+
+// Connector allows to interact with the Git command-line interface.
+type Connector interface {
+	GetCommitTemplatePath() (path string, global bool, err error)
+	SetCommitTemplate(path string) (err error)
+	UnsetCommitTemplate() (err error)
+}

--- a/git/integration.go
+++ b/git/integration.go
@@ -18,14 +18,20 @@ func (e *NoCommitTemplateConfigurationError) Error() string {
 	return "No commit.template configuration found"
 }
 
+// CLI allows to operate the system's Git command-line interface.
+type CLI struct{}
+
 // GetCommitTemplatePath returns the current commit.template configuration
 // and whether it provides from global configuration or not.
-func GetCommitTemplatePath() (path string, global bool, err error) {
+func (cli *CLI) GetCommitTemplatePath() (path string, global bool, err error) {
 	cmd := exec.Command("git", "config", "--show-origin", "--get", "commit.template")
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
-	cmd.Run()
+	err = cmd.Run()
+	if err != nil {
+		return
+	}
 
 	global = isGlobal(out.Bytes())
 	path, err = commitTemplatePath(out.String())
@@ -33,8 +39,8 @@ func GetCommitTemplatePath() (path string, global bool, err error) {
 }
 
 // SetCommitTemplate configures Git locally to use a commit template.
-func SetCommitTemplate(path string) (err error) {
-	err = UnsetCommitTemplate()
+func (cli *CLI) SetCommitTemplate(path string) (err error) {
+	err = cli.UnsetCommitTemplate()
 	if err != nil {
 		return
 	}
@@ -47,7 +53,7 @@ func SetCommitTemplate(path string) (err error) {
 }
 
 // UnsetCommitTemplate removes local Git commit template configuration.
-func UnsetCommitTemplate() (err error) {
+func (cli *CLI) UnsetCommitTemplate() (err error) {
 	cmd := exec.Command("git", "config", "--unset", "commit.template")
 	_ = cmd.Run()
 	return

--- a/git/integration.go
+++ b/git/integration.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 )
 
-const globalConfigOutputRegexp = `file:.git/config`
+const globalConfigOutputRegexp = `file:.*\.gitconfig`
 const commitTemplatePathRegexp = `config\s+(.*)\s*`
 
 // NoCommitTemplateConfigurationError indicates that commit.template is unset.

--- a/git/integration.go
+++ b/git/integration.go
@@ -49,7 +49,8 @@ func (cli *CLI) GetCommitTemplatePath() (path string, global bool, err error) {
 }
 
 // SetCommitTemplate configures Git locally to use a commit template.
-func (cli *CLI) SetCommitTemplate(path string) (err error) {
+func (cli *CLI) SetCommitTemplate(path string) error {
+	cli.unsetCommitTemplate()
 	return cli.setCommitTemplate(path)
 }
 
@@ -80,21 +81,12 @@ func _getCommitTemplatePath() (out bytes.Buffer, err error) {
 	return
 }
 
-func _setCommitTemplate(path string) (err error) {
-	err = _unsetCommitTemplate()
-	if err != nil {
-		return
-	}
+func _setCommitTemplate(path string) error {
 	cmd := exec.Command("git", "config", "--add", "commit.template", path)
-	err = cmd.Run()
-	if err != nil {
-		return
-	}
-	return
+	return cmd.Run()
 }
 
-func _unsetCommitTemplate() (err error) {
+func _unsetCommitTemplate() error {
 	cmd := exec.Command("git", "config", "--unset", "commit.template")
-	_ = cmd.Run()
-	return
+	return cmd.Run()
 }

--- a/git/integration.go
+++ b/git/integration.go
@@ -19,44 +19,43 @@ func (e *NoCommitTemplateConfigurationError) Error() string {
 }
 
 // CLI allows to operate the system's Git command-line interface.
-type CLI struct{}
+type CLI struct {
+	getCommitTemplatePath func() (out bytes.Buffer, err error)
+	setCommitTemplate     func(path string) (err error)
+	unsetCommitTemplate   func() (err error)
+}
+
+// NewCLI returns a new CLI that wraps the Git command-line interface
+func NewCLI() *CLI {
+	return &CLI{
+		getCommitTemplatePath: _getCommitTemplatePath,
+		setCommitTemplate:     _setCommitTemplate,
+		unsetCommitTemplate:   _unsetCommitTemplate,
+	}
+}
 
 // GetCommitTemplatePath returns the current commit.template configuration
 // and whether it provides from global configuration or not.
 func (cli *CLI) GetCommitTemplatePath() (path string, global bool, err error) {
-	cmd := exec.Command("git", "config", "--show-origin", "--get", "commit.template")
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err = cmd.Run()
+	var output bytes.Buffer
+	output, err = cli.getCommitTemplatePath()
 	if err != nil {
 		return
 	}
 
-	global = isGlobal(out.Bytes())
-	path, err = commitTemplatePath(out.String())
+	global = isGlobal(output.Bytes())
+	path, err = commitTemplatePath(output.String())
 	return
 }
 
 // SetCommitTemplate configures Git locally to use a commit template.
 func (cli *CLI) SetCommitTemplate(path string) (err error) {
-	err = cli.UnsetCommitTemplate()
-	if err != nil {
-		return
-	}
-	cmd := exec.Command("git", "config", "--add", "commit.template", path)
-	err = cmd.Run()
-	if err != nil {
-		return
-	}
-	return
+	return cli.setCommitTemplate(path)
 }
 
 // UnsetCommitTemplate removes local Git commit template configuration.
 func (cli *CLI) UnsetCommitTemplate() (err error) {
-	cmd := exec.Command("git", "config", "--unset", "commit.template")
-	_ = cmd.Run()
-	return
+	return cli.unsetCommitTemplate()
 }
 
 func commitTemplatePath(output string) (string, error) {
@@ -71,4 +70,31 @@ func commitTemplatePath(output string) (string, error) {
 func isGlobal(output []byte) bool {
 	re := regexp.MustCompile(globalConfigOutputRegexp)
 	return re.Match(output)
+}
+
+func _getCommitTemplatePath() (out bytes.Buffer, err error) {
+	cmd := exec.Command("git", "config", "--show-origin", "--get", "commit.template")
+
+	cmd.Stdout = &out
+	err = cmd.Run()
+	return
+}
+
+func _setCommitTemplate(path string) (err error) {
+	err = _unsetCommitTemplate()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command("git", "config", "--add", "commit.template", path)
+	err = cmd.Run()
+	if err != nil {
+		return
+	}
+	return
+}
+
+func _unsetCommitTemplate() (err error) {
+	cmd := exec.Command("git", "config", "--unset", "commit.template")
+	_ = cmd.Run()
+	return
 }

--- a/git/integration_test.go
+++ b/git/integration_test.go
@@ -1,3 +1,97 @@
-package git_test
+package git
 
-// The nice bit is that we have Git at hand
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+const exampleGlobalConfigOutput = "file:/home/alice/.gitconfig	/home/alice/.pair"
+const exampleLocalConfigOutput = "file:.git/config	/home/bob/.pair"
+
+func TestIntegration(t *testing.T) {
+
+	t.Run("GetCommitTemplatePath()", func(t *testing.T) {
+
+		t.Run("when Git command returns an error", func(t *testing.T) {
+			cli := NewCLI()
+			var emptyBuffer bytes.Buffer
+			cli.getCommitTemplatePath = func() (bytes.Buffer, error) {
+				return emptyBuffer, errors.New("Git command failed")
+			}
+
+			_, _, err := cli.GetCommitTemplatePath()
+			if err == nil {
+				t.Error("Expected error, got none")
+			}
+		})
+
+		t.Run("when Git command succeeds and returns global config", func(t *testing.T) {
+			cli := NewCLI()
+			output := bytes.NewBufferString(exampleGlobalConfigOutput)
+			cli.getCommitTemplatePath = func() (bytes.Buffer, error) {
+				return *output, nil
+			}
+
+			path, global, err := cli.GetCommitTemplatePath()
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+			if path != "/home/alice/.pair" {
+				t.Errorf("Unexpected error %v", path)
+			}
+			if !global {
+				t.Error("Expected global flag to be true, got false")
+			}
+		})
+
+		t.Run("when Git command succeeds and returns repository config", func(t *testing.T) {
+			cli := NewCLI()
+			output := bytes.NewBufferString(exampleLocalConfigOutput)
+			cli.getCommitTemplatePath = func() (bytes.Buffer, error) {
+				return *output, nil
+			}
+
+			path, global, err := cli.GetCommitTemplatePath()
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+			if path != "/home/bob/.pair" {
+				t.Errorf("Unexpected error %v", path)
+			}
+			if global {
+				t.Error("Expected global flag to be false, got true")
+			}
+		})
+	})
+
+	t.Run("SetCommitTemplate()", func(t *testing.T) {
+
+		t.Run("when Git command returns an error", func(t *testing.T) {
+			cli := NewCLI()
+			cli.setCommitTemplate = func(path string) error {
+				return errors.New("Git command failed")
+			}
+
+			err := cli.SetCommitTemplate("path")
+			if err == nil {
+				t.Error("Expected error, got none")
+			}
+		})
+	})
+
+	t.Run("UnsetCommitTemplate()", func(t *testing.T) {
+
+		t.Run("when Git command returns an error", func(t *testing.T) {
+			cli := NewCLI()
+			cli.unsetCommitTemplate = func() error {
+				return errors.New("Git command failed")
+			}
+
+			err := cli.UnsetCommitTemplate()
+			if err == nil {
+				t.Error("Expected error, got none")
+			}
+		})
+	})
+}

--- a/git/integration_test.go
+++ b/git/integration_test.go
@@ -78,6 +78,18 @@ func TestIntegration(t *testing.T) {
 				t.Error("Expected error, got none")
 			}
 		})
+
+		t.Run("when unsetting the template fails", func(t *testing.T) {
+			cli := NewCLI()
+			cli.unsetCommitTemplate = func() error {
+				return errors.New("Git command failed")
+			}
+
+			err := cli.SetCommitTemplate("path")
+			if err != nil {
+				t.Errorf("Expected no error, got %+v", err)
+			}
+		})
 	})
 
 	t.Run("UnsetCommitTemplate()", func(t *testing.T) {

--- a/pair.go
+++ b/pair.go
@@ -12,9 +12,13 @@ import (
 
 const version = "1.0.0-alpha" // adheres to semantic versioning
 
+func GetGitConnector() git.Connector {
+	return &git.CLI{}
+}
+
 // Stop removes the co-author declaration from the commit template, if any.
-func Stop(out, errors io.Writer) error {
-	commitTemplatePath, _, err := git.GetCommitTemplatePath()
+func Stop(cli git.Connector, out, errors io.Writer) error {
+	commitTemplatePath, _, err := cli.GetCommitTemplatePath()
 	ensureExists(commitTemplatePath)
 	if err != nil {
 		switch err.(type) {
@@ -55,14 +59,14 @@ func Version(out, errors io.Writer) error {
 
 // With adds a co-author declaration to the current commit template if any,
 // or creates a new commit template and configures Git to use it.
-func With(out, errors io.Writer, pair string) error {
+func With(cli git.Connector, out, errors io.Writer, pair string) error {
 
-	err := Stop(out, errors)
+	err := Stop(cli, out, errors)
 	if err != nil {
 		return err
 	}
 
-	commitTemplatePath, _, err := git.GetCommitTemplatePath()
+	commitTemplatePath, _, err := cli.GetCommitTemplatePath()
 	if err != nil {
 		if err != nil {
 			switch err.(type) {
@@ -76,7 +80,7 @@ func With(out, errors io.Writer, pair string) error {
 	if commitTemplatePath == "" {
 		commitTemplatePath = defaultCommitTemplatePath()
 		ensureExists(commitTemplatePath)
-		err = git.SetCommitTemplate(commitTemplatePath)
+		err = cli.SetCommitTemplate(commitTemplatePath)
 		if err != nil {
 			return err
 		}

--- a/pair.go
+++ b/pair.go
@@ -13,7 +13,7 @@ import (
 const version = "1.0.0-alpha" // adheres to semantic versioning
 
 func GetGitConnector() git.Connector {
-	return &git.CLI{}
+	return git.NewCLI()
 }
 
 // Stop removes the co-author declaration from the commit template, if any.

--- a/pair_test.go
+++ b/pair_test.go
@@ -2,10 +2,13 @@ package pair_test
 
 import (
 	"bytes"
+	"fmt"
+	"path/filepath"
 	"regexp"
 	"testing"
 
 	"github.com/gonzalo-bulnes/pair"
+	"github.com/gonzalo-bulnes/pair/git"
 )
 
 // semverRegexp matches the most common semantinc version strings.
@@ -24,4 +27,189 @@ func TestPair(t *testing.T) {
 			t.Errorf("Expected (semantic) version to be put out, was not")
 		}
 	})
+
+	t.Run("Stop()", func(t *testing.T) {
+
+		unexpectedErr := fmt.Errorf("some specific error")
+
+		testcases := []struct {
+			description                        string
+			git                                *MockGitConnector
+			expectedGetCommitTemplatePathCount int
+			expectedSetCommitTemplateCount     int
+			expectedUnsetCommitTemplateCount   int
+			expectedError                      error
+		}{
+			{
+				description: `When commit.template can't be fetched, error should be returned`,
+				git: &MockGitConnector{
+					GetCommitTemplatePathError: unexpectedErr,
+				},
+				expectedGetCommitTemplatePathCount: 1,
+				expectedError:                      unexpectedErr,
+			},
+			{
+				description: `When no commit.template is set, no errors should be returned`,
+				git: &MockGitConnector{
+					GetCommitTemplatePathError: &git.NoCommitTemplateConfigurationError{},
+				},
+				expectedGetCommitTemplatePathCount: 1,
+				expectedError:                      nil,
+			},
+			{
+				description: `With empty commit.template, no errors should be returned`,
+				git: &MockGitConnector{
+					GetCommitTemplatePathError: nil,
+				},
+				expectedGetCommitTemplatePathCount: 1,
+				expectedError:                      nil,
+			},
+			{
+				description: `With existing commit.template, no errors should be returned`,
+				git: &MockGitConnector{
+					CommitTemplatePath:         full("existing.txt"),
+					GetCommitTemplatePathError: nil,
+				},
+				expectedGetCommitTemplatePathCount: 1,
+				expectedError:                      nil,
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.description, func(t *testing.T) {
+				var out, error bytes.Buffer
+				err := pair.Stop(tc.git, &out, &error)
+				if err != tc.expectedError {
+					t.Errorf("Expected error to be %v, got %v", tc.expectedError, err)
+				}
+				if tc.git.GetCommitTemplatePathCount != tc.expectedGetCommitTemplatePathCount {
+					t.Errorf("Expected GetCommitTemplatePath to be called %d time(s), was %d",
+						tc.expectedGetCommitTemplatePathCount, tc.git.GetCommitTemplatePathCount)
+				}
+				if tc.git.SetCommitTemplateCount != tc.expectedSetCommitTemplateCount {
+					t.Errorf("Expected SetCommitTemplate to be called %d time(s), was %d",
+						tc.expectedSetCommitTemplateCount, tc.git.SetCommitTemplateCount)
+				}
+				if tc.git.UnsetCommitTemplateCount != tc.expectedUnsetCommitTemplateCount {
+					t.Errorf("Expected UnsetCommitTemplate to be called %d time(s), was %d",
+						tc.expectedUnsetCommitTemplateCount, tc.git.UnsetCommitTemplateCount)
+				}
+			})
+		}
+	})
+
+	t.Run("With()", func(t *testing.T) {
+
+		unexpectedErr := fmt.Errorf("some specific error")
+
+		testcases := []struct {
+			description                        string
+			git                                *MockGitConnector
+			expectedGetCommitTemplatePathCount int
+			expectedSetCommitTemplateCount     int
+			expectedUnsetCommitTemplateCount   int
+			expectedError                      error
+		}{
+			{
+				description: `When commit.template can't be fetched, error should be returned`,
+				git: &MockGitConnector{
+					GetCommitTemplatePathError: unexpectedErr,
+				},
+				expectedGetCommitTemplatePathCount: 1,
+				expectedSetCommitTemplateCount:     0,
+				expectedUnsetCommitTemplateCount:   0,
+				expectedError:                      unexpectedErr,
+			},
+			{
+				description: `When no commit.template is set, no errors should be returned`,
+				git: &MockGitConnector{
+					GetCommitTemplatePathError: &git.NoCommitTemplateConfigurationError{},
+				},
+				expectedGetCommitTemplatePathCount: 2,
+				expectedSetCommitTemplateCount:     1,
+				expectedUnsetCommitTemplateCount:   0,
+				expectedError:                      nil,
+			},
+			{
+				description: `When commit.template can't be set, error should be returned`,
+				git: &MockGitConnector{
+					SetCommitTemplateError: unexpectedErr,
+				},
+				expectedGetCommitTemplatePathCount: 2,
+				expectedSetCommitTemplateCount:     1,
+				expectedUnsetCommitTemplateCount:   0,
+				expectedError:                      unexpectedErr,
+			},
+			{
+				description: `With no errors when fetching commit.template, no errors should be returned`,
+				git: &MockGitConnector{
+					GetCommitTemplatePathError: nil,
+				},
+				expectedGetCommitTemplatePathCount: 2,
+				expectedSetCommitTemplateCount:     1,
+				expectedUnsetCommitTemplateCount:   0,
+				expectedError:                      nil,
+			},
+			{
+				description: `With existing commit.template, setting should not be changed`,
+				git: &MockGitConnector{
+					CommitTemplatePath:         full("simple.txt"),
+					GetCommitTemplatePathError: nil,
+				},
+				expectedGetCommitTemplatePathCount: 2,
+				expectedSetCommitTemplateCount:     0,
+				expectedError:                      nil,
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.description, func(t *testing.T) {
+				var out, error bytes.Buffer
+				err := pair.With(tc.git, &out, &error, "Alice <alice@example.com>")
+				if err != tc.expectedError {
+					t.Errorf("Expected error to be %v, got %v", tc.expectedError, err)
+				}
+				if tc.git.GetCommitTemplatePathCount != tc.expectedGetCommitTemplatePathCount {
+					t.Errorf("Expected GetCommitTemplatePath to be called %d time(s), was %d",
+						tc.expectedGetCommitTemplatePathCount, tc.git.GetCommitTemplatePathCount)
+				}
+				if tc.git.SetCommitTemplateCount != tc.expectedSetCommitTemplateCount {
+					t.Errorf("Expected SetCommitTemplate to be called %d time(s), was %d",
+						tc.expectedSetCommitTemplateCount, tc.git.SetCommitTemplateCount)
+				}
+				if tc.git.UnsetCommitTemplateCount != tc.expectedUnsetCommitTemplateCount {
+					t.Errorf("Expected UnsetCommitTemplate to be called %d time(s), was %d",
+						tc.expectedUnsetCommitTemplateCount, tc.git.UnsetCommitTemplateCount)
+				}
+			})
+		}
+	})
+}
+
+type MockGitConnector struct {
+	CommitTemplatePath         string
+	CommitTemplatePathGlobal   bool
+	GetCommitTemplatePathError error
+	SetCommitTemplateError     error
+	UnsetCommitTemplateError   error
+	GetCommitTemplatePathCount int
+	SetCommitTemplateCount     int
+	UnsetCommitTemplateCount   int
+}
+
+func (m *MockGitConnector) GetCommitTemplatePath() (path string, global bool, err error) {
+	m.GetCommitTemplatePathCount += 1
+	return m.CommitTemplatePath, m.CommitTemplatePathGlobal, m.GetCommitTemplatePathError
+}
+func (m *MockGitConnector) SetCommitTemplate(path string) (err error) {
+	m.SetCommitTemplateCount += 1
+	return m.SetCommitTemplateError
+}
+func (m *MockGitConnector) UnsetCommitTemplate() (err error) {
+	m.UnsetCommitTemplateCount += 1
+	return m.UnsetCommitTemplateError
+}
+
+func full(path string) string {
+	return filepath.Join("testdata", path)
 }

--- a/testdata/simple.txt
+++ b/testdata/simple.txt
@@ -1,0 +1,3 @@
+Add secret message
+
+Co-Authored-By: Alice <alice@example.com>


### PR DESCRIPTION
This PR is a follow up on #3 

It adds some test coverage to the Pair subcommands. (Previously, #5 had revealed how much it was needed!)