### PR TITLE
Fix the 'Index out of range error' when no args are passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ define GOLANG_CMD
 		--volume "$$(pwd)":/app \
 		--env "GOPATH=/gopath" \
 		--workdir /app \
-		golang:1.10-alpine
+		golang:1.12-alpine
 endef
 
 .PHONY: all

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,13 +19,21 @@ type config struct {
 type argumentsError struct{}
 
 func (e *argumentsError) Error() string {
-	return "Usage: pair with <email>\n\nExample:\n\n  pair with 'Alice <alice@example.com>'\n"
+	return `Usage: 
+pair with <email>
+Example:
+  pair with 'Alice <alice@example.com>'
+
+pair stop
+Example:
+  pair stop
+`
 }
 
 func main() {
 	err := checkArgs(os.Args)
 	if err != nil {
-		fail(os.Stderr, err, 0)
+		os.Exit(fail(os.Stderr, err, 1))
 	}
 
 	switch os.Args[1] {

--- a/pair.go
+++ b/pair.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gonzalo-bulnes/pair/git"
 )
 
-const version = "1.0.0-alpha" // adheres to semantic versioning
+const version = "1.0.1-alpha" // adheres to semantic versioning
 
 // Stop removes the co-author declaration from the commit template, if any.
 func Stop(out, errors io.Writer) error {


### PR DESCRIPTION
Error when no args are passed

```
$ pair
Usage: pair with <email>

Example:

  pair with 'Alice <alice@example.com>'
panic: runtime error: index out of range

goroutine 1 [running]:
main.main()
	/Users/alinalawala/go/src/github.com/gonzalo-bulnes/pair/cmd/main.go:31 +0x2fc
```

After the patch

```
$ pair
Usage:
pair with <email>
Example:
  pair with 'Alice <alice@example.com>'

pair stop
Example:
  pair stop
```

TODO

- [ ] Add missing tests