### PR TITLE
Move to using Go Modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ define GOLANG_CMD
 		--volume "$$(pwd)":/app \
 		--env "GOPATH=/gopath" \
 		--workdir /app \
-		golang:1.10-alpine
+		golang:1.12-alpine
 endef
 
 .PHONY: all

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gonzalo-bulnes/pair
+
+go 1.12


### PR DESCRIPTION
**When I** work on `pair`
**I want** setting up the project to be straightforward 
**So that** I can focus on the code itself

Recent Go versions use [Go Modules](https://github.com/golang/go/wiki/Modules) for dependency management. So far, I've found it to be my preferred way to manage dependencies in Go and [migrating](https://github.com/golang/go/wiki/Modules#migrating-to-modules) was quick (details in the commit message).

See also #9