### PR TITLE
Fix clean target: remove all build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ build: pair-linux-amd64 pair-darwin-amd64
 
 .PHONY: clean
 clean:
-	@rm -f pair
+	@rm -f pair-linux-amd64
+	@rm -f pair-darwin-amd64
 
 .PHONY: install-for-testing
 install-for-testing:


### PR DESCRIPTION
**When I** `make all` to build binary releases 
**I want** the binaries to be re-built inconditionally 
**So that** I know any binary I built is up-to-date 

